### PR TITLE
Update return type hints in transcription methods

### DIFF
--- a/clipsai/transcribe/transcription.py
+++ b/clipsai/transcribe/transcription.py
@@ -180,7 +180,7 @@ class Transcription:
         self,
         start_time: float = None,
         end_time: float = None,
-    ) -> list:
+    ) -> list[dict]:
         """
         Returns the character info of the transcription
 
@@ -215,7 +215,7 @@ class Transcription:
         self,
         start_time: float = None,
         end_time: float = None,
-    ) -> list:
+    ) -> list[dict]:
         """
         Returns the word info of the text
 
@@ -252,7 +252,7 @@ class Transcription:
         self,
         start_time: float = None,
         end_time: float = None,
-    ) -> list:
+    ) -> list[dict]:
         """
         Returns the sentence information of the text.
 


### PR DESCRIPTION
## Summary
- change `get_char_info`, `get_word_info`, and `get_sentence_info` return type hints to `list[dict]`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6846b1615ee0832bb85e26a0c21bf025